### PR TITLE
Fix JCenter not able to download Taplytics RN dependency 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
+        // https://blog.gradle.org/jcenter-shutdown
         mavenCentral()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
@@ -38,4 +40,5 @@ dependencies {
 repositories {
     maven { url "https://github.com/taplytics/Taplytics-Android-SDK/raw/master/AndroidStudio/" }
     mavenCentral()
+    jcenter()
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -38,5 +38,4 @@ dependencies {
 repositories {
     maven { url "https://github.com/taplytics/Taplytics-Android-SDK/raw/master/AndroidStudio/" }
     mavenCentral()
-    jcenter()
 }


### PR DESCRIPTION
## Description

Android builds failing due to some libraries that we have as dependencies still pointing to JCenter.  which was blocking our builds from succeded since JCenter is down. [Check this blog post](https://blog.gradle.org/jcenter-shutdown) to know more about it.

## Notable Changes

Point to MavenCentral.
